### PR TITLE
Fix unable to find chrome on 64-bit system

### DIFF
--- a/src/neel.nim
+++ b/src/neel.nim
@@ -176,8 +176,11 @@ proc findChromeMac*: string =
 proc findChromeWindows*: string =
     #const defaultPath = r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe" # for registery
     const defaultPath = r"\Program Files (x86)\Google\Chrome\Application\chrome.exe"
+    const backupPath = r"\Program Files\Google\Chrome\Application\chrome.exe"
     if fileExists(absolutePath(defaultPath)):
         result = defaultPath
+    if fileExists(absolutePath(backupPath)):
+        result = backupPath
     else: # include registry search in future versions to account for any location
         raise newException(CustomError, "could not find Chrome in Program Files (x86) directory")
 


### PR DESCRIPTION
Currently if Chrome is installed in Program Files/ rather than Program Files (x86)/ Neel cannot locate Chrome. This adds a backup path for resolving this issue.