### PR TITLE
Implement mummy instead of jester/ws

### DIFF
--- a/examples/FilePicker/config.nims
+++ b/examples/FilePicker/config.nims
@@ -1,0 +1,3 @@
+switch("threads", "on")
+switch("mm", "orc")
+switch("mm", "arc")

--- a/neel.nimble
+++ b/neel.nimble
@@ -12,8 +12,7 @@ skipDirs      = @["examples","windows"]
 # Dependencies
 
 requires "nim >= 1.2.2"
-requires "jester >= 0.5.0"
-requires "ws >= 0.4.2"
+requires "mummy"
 
 import os
 


### PR DESCRIPTION
This is just an option. If you feel this is not right in the direction of the project I can close this draft. If you feel this is acceptable I can make a full pr.

### Why switch to mummy?
* less dependencies, only need mummy, not jester and ws
* Fixes [this](https://github.com/Niminem/Neel/blob/master/src/neel.nim#L325:L326) issue
* Removes async necessity (Might fix #18 )
* Just my opinion about not using jester inside another lib

If anyone can think of any more reasons let me know
### Other optimizations
* Added `compileTime` pragma to `getAssets`